### PR TITLE
Fixing Compatibility with newest Arch Linux version and newest libalpm version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ hex = { version = "0.4", features = ["serde"] }
 speedy = "0.8"
 
 # ArchLinux package management system
-alpm = "2.2"
-alpm-utils = "2.0"
-pacmanconf = "2.0"
+alpm = "4.0"
+alpm-utils = "4.0"
+pacmanconf = "3.0"
 
 # Hardware identification
 devices = "0.3"

--- a/packaging/archlinux-driver-manager-local/PKGBUILD
+++ b/packaging/archlinux-driver-manager-local/PKGBUILD
@@ -41,7 +41,7 @@ build() {
 
 package() {
     # To bypass makepkg's dependency check during build-time
-    depends+=("$PACKAGE_NAME_STUB-db")
+    optdepends+=("$PACKAGE_NAME_STUB-db")
 
     cd "$PROJECT_DIRECTORY"
     install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$PACKAGE_NAME_STUB/LICENSE"

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -18,7 +18,7 @@ impl PackageManager {
         }
     }
 
-    pub fn get<S: AsRef<str>>(&self, package_name: S) -> Option<Package> {
+    pub fn get<S: AsRef<str>>(&self, package_name: S) -> Option<&Package> {
         let db = self.handle.localdb();
         db.pkg(package_name.as_ref()).ok()
     }
@@ -58,7 +58,7 @@ impl PackageManager {
             let package = self.get(package_name);
 
             if let Some(package) = package {
-                self.handle.trans_remove_pkg(package).unwrap();
+                self.handle.trans_remove_pkg(&package).unwrap();
                 actual_remove_list.push(package_name.to_owned());
             } else {
                 self.handle.trans_release().unwrap();


### PR DESCRIPTION
There is not a lot to say, but the alpm requirement is now compatible with libalpm=^v15.xx.xx
and the cycling dependency is fixed, so you can install at all